### PR TITLE
chore: Adds the OAI RAN CU ROCK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore: "

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Description
+
+Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that validate the behaviour of the software.
+- [ ] I validated that new and existing tests pass locally with my changes.
+- [ ] Any dependent changes have been merged and published in downstream modules.

--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -1,0 +1,12 @@
+name: "Dependabot Auto Approve and Merge"
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    uses: canonical/sdcore-github-workflows/.github/workflows/dependabot_pr.yaml@v1.0.0

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,11 @@
+name: Sync Issues to JIRA
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+
+jobs:
+  update:
+    name: Update Issue
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v1.0.0
+    secrets: inherit

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,25 @@
+name: Main
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+
+  build-rock:
+    uses: canonical/sdcore-github-workflows/.github/workflows/build-rock.yaml@v1.0.0
+
+  scan-rock:
+    needs: build-rock
+    uses: canonical/sdcore-github-workflows/.github/workflows/scan-rock.yaml@v1.0.0
+
+  publish-rock:
+    if: github.ref_name == 'main'
+    needs: scan-rock
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-rock.yaml@v1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.idea
+.vscode/
+
+# Rockcraft
+*.rock

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/telco

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Build and deploy
+
+```bash
+rockcraft pack -v
+sudo skopeo --insecure-policy copy oci-archive:oai-ran-cu_2.1.1_amd64.rock docker-daemon:oai-ran-cu:2.1.1
+docker run -d oai-ran-cu:2.1.1
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
 
 ```bash
 rockcraft pack -v
-sudo skopeo --insecure-policy copy oci-archive:oai-ran-cu_2.1.1_amd64.rock docker-daemon:oai-ran-cu:2.1.1
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:oai-ran-cu_2.1.1_amd64.rock docker-daemon:oai-ran-cu:2.1.1
 docker run -d oai-ran-cu:2.1.1
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# oai-ran-cu-rock
+# OAI RAN Central Unit (CU) ROCK
+
+Container image for the OAI RAN Central Unit (CU).
+
+## Usage
+
+```console
+docker pull ghcr.io/canonical/oai-ran-cu:2.1.1
+docker run -it ghcr.io/canonical/oai-ran-cu:2.1.1
+```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,6 +8,8 @@ platforms:
   amd64:
 
 environment:
+  DEBIAN_FRONTEND: noninteractive
+  LD_LIBRARY_PATH: "/usr/lib/x86_64-linux-gnu:/usr/local/lib"
   OAI_GDBSTACKS: "1"
   TZ: UTC
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,6 +8,7 @@ platforms:
   amd64:
 
 environment:
+  OAI_GDBSTACKS: "1"
   TZ: UTC
 
 parts:
@@ -19,6 +20,10 @@ parts:
     build-environment:
       - BUILD_UHD_FROM_SOURCE: "True"
       - UHD_VERSION: "4.4.0.0"
+    overlay-packages:
+      - gdb
+      - libconfig9
+      - libsctp1
     build-packages:
       - g++-12
       - gcc-12
@@ -61,5 +66,4 @@ parts:
       - iperf3
       - iproute2
       - iputils-ping
-      - libsctp1
       - net-tools

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -52,7 +52,7 @@ parts:
       - usr/local/lib/*
       - opt/oai-gnb/bin/*
 
-  runtime-deps:
+  tools:
     after:
       - cu
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,65 @@
+name: oai-ran-cu
+base: ubuntu@22.04
+version: '2.1.1'
+summary: OAI RAN CU ROCK
+license: Apache-2.0
+description: Container image for the OAI RAN Central Unit (CU).
+platforms:
+  amd64:
+
+environment:
+  TZ: UTC
+
+parts:
+  cu:
+    plugin: nil
+    source: https://gitlab.eurecom.fr/oai/openairinterface5g.git
+    source-type: git
+    source-branch: develop
+    build-environment:
+      - BUILD_UHD_FROM_SOURCE: "True"
+      - UHD_VERSION: "4.4.0.0"
+    build-packages:
+      - g++-12
+      - gcc-12
+    override-build: |
+      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+      /bin/sh oaienv
+      cd cmake_targets && mkdir -p log
+      ./build_oai -I -w USRP --install-optional-packages
+      ./build_oai -c --ninja \
+      --gNB \
+      --build-lib "telnetsrv enbscope uescope nrscope" \
+      -w USRP -t Ethernet \
+      --build-e2 --cmake-opt -DXAPP_MULTILANGUAGE=OFF \
+      --noavx512 \
+      --cmake-opt -DCMAKE_C_FLAGS="-Werror" --cmake-opt -DCMAKE_CXX_FLAGS="-Werror"
+      
+      cp -r ran_build/build $CRAFT_PART_INSTALL
+    organize:
+      build/liboai_eth_transpro.so: usr/local/lib/liboai_eth_transpro.so
+      build/libcoding.so: usr/local/lib/libcoding.so
+      build/libparams_libconfig.so: usr/local/lib/libparams_libconfig.so
+      build/libdfts.so: usr/local/lib/libdfts.so
+      build/libldpc.so: usr/local/lib/libldpc.so
+      build/libldpc_optim.so: usr/local/lib/libldpc_optim.so
+      build/libldpc_optim8seg.so: usr/local/lib/libldpc_optim8seg.so
+      build/libldpc_orig.so: usr/local/lib/libldpc_orig.so
+      build/libtelnetsrv.so: usr/local/lib/libtelnetsrv.so
+      build/libtelnetsrv_ci.so: usr/local/lib/libtelnetsrv_ci.so
+      build/nr-softmodem: opt/oai-gnb/bin/nr-softmodem
+    stage:
+      - usr/local/lib/*
+      - opt/oai-gnb/bin/*
+
+  runtime-deps:
+    after:
+      - cu
+    plugin: nil
+    stage-packages:
+      - iperf
+      - iperf3
+      - iproute2
+      - iputils-ping
+      - libsctp1
+      - net-tools


### PR DESCRIPTION
This PR adds the initial version of the OAI RAN CU ROCK.

The version of the ROCK is set to `2.1.1` which doesn't exist in the upstream. This is to indicate that we're temporarily using the code from the `develop` branch (latest release, `2.1.0`, is over 5 months old). There's a `2.2.0` release planned for end of August. Once it's available, we should switch to that release.