### PR TITLE
chore: Bumps upstream version to 2.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
 
 ```bash
 rockcraft pack -v
-sudo rockcraft.skopeo --insecure-policy copy oci-archive:oai-ran-cu_2.2.0_amd64.rock docker-daemon:oai-ran-cu:2.2.0
-docker run -d oai-ran-cu:2.2.0
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:oai-ran-cu_2.3.0_amd64.rock docker-daemon:oai-ran-cu:2.3.0
+docker run -d oai-ran-cu:2.3.0
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for the OAI RAN Central Unit (CU).
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/oai-ran-cu:2.2.0
-docker run -it ghcr.io/canonical/oai-ran-cu:2.2.0
+docker pull ghcr.io/canonical/oai-ran-cu:2.3.0
+docker run -it ghcr.io/canonical/oai-ran-cu:2.3.0
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: oai-ran-cu
 base: ubuntu@24.04
-version: '2.2.0'
+version: '2.3.0'
 summary: OAI RAN CU ROCK
 license: Apache-2.0
 description: Container image for the OAI RAN Central Unit (CU).


### PR DESCRIPTION
# Description

Bumps upstream version to `2.3.0`

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
